### PR TITLE
Speed up sparse matrix assignment

### DIFF
--- a/R/decon.R
+++ b/R/decon.R
@@ -519,7 +519,22 @@ setMethod(
       z = as.integer(res$z),
       pseudocount = 1e-20
     )
-    estRmat[seq(nrow(counts)), which(batch == bat)] <- estRmat.temp
+    
+    # Speed up sparse matrix value assignment by cbind -> order recovery
+    
+    allCol <- paste0("col_", 1:ncol(estRmat))
+    colnames(estRmat) <- allCol
+    
+    subCol <- paste0("col_", which(batch == bat))
+    colnames(estRmat.temp) <- subCol
+    
+    estRmat <- estRmat[, !(allCol %in% subCol)]
+    estRmat <- cbind(estRmat, estRmat.temp)
+    
+    # Recover order
+    estRmat <- estRmat[, allCol]
+    
+    #(Old method) estRmat[seq(nrow(counts)), which(batch == bat)] <- estRmat.temp
     dimnames(estRmat) <- list(geneNames, allCellNames)
 
     resBatch[[bat]] <- list(

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // decontXEM
 Rcpp::List decontXEM(const Eigen::MappedSparseMatrix<double>& counts, const NumericVector& counts_colsums, const NumericVector& theta, const bool& estimate_eta, const NumericMatrix& eta, const NumericMatrix& phi, const IntegerVector& z, const bool& estimate_delta, const NumericVector& delta, const double& pseudocount);
 RcppExport SEXP _celda_decontXEM(SEXP countsSEXP, SEXP counts_colsumsSEXP, SEXP thetaSEXP, SEXP estimate_etaSEXP, SEXP etaSEXP, SEXP phiSEXP, SEXP zSEXP, SEXP estimate_deltaSEXP, SEXP deltaSEXP, SEXP pseudocountSEXP) {


### PR DESCRIPTION
Hi @joshua-d-campbell, I have fixed the slow issue with sparse matrix assignment. The code does cbind on different batch of sparse matrices and then recover the original column order. I have tested it with/without inputting a batch parameter to decontX and the estRmatrix looks good. Didn't do a thorough test though as the change is minor. Let me know! 