### PR TITLE
Fix the background input bug when input class is not SingleCellExperiment

### DIFF
--- a/R/decon.R
+++ b/R/decon.R
@@ -246,6 +246,8 @@ setMethod("decontX", "ANY", function(x,
     # Remove cells with the same ID between x and the background matrix
     background <- .checkBackground(x = x, background = background,
                                    logfile = logfile, verbose = verbose)
+
+    countsBackground <- background
   }
 
   .decontX(

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -6,6 +6,11 @@
 
 using namespace Rcpp;
 
+#ifdef RCPP_USE_GLOBAL_ROSTREAM
+Rcpp::Rostream<true>&  Rcpp::Rcout = Rcpp::Rcpp_cout_get();
+Rcpp::Rostream<false>& Rcpp::Rcerr = Rcpp::Rcpp_cerr_get();
+#endif
+
 // decontXEM
 Rcpp::List decontXEM(const Eigen::MappedSparseMatrix<double>& counts, const NumericVector& counts_colsums, const NumericVector& theta, const bool& estimate_eta, const NumericMatrix& eta, const NumericMatrix& phi, const IntegerVector& z, const bool& estimate_delta, const NumericVector& delta, const double& pseudocount);
 RcppExport SEXP _celda_decontXEM(SEXP countsSEXP, SEXP counts_colsumsSEXP, SEXP thetaSEXP, SEXP estimate_etaSEXP, SEXP etaSEXP, SEXP phiSEXP, SEXP zSEXP, SEXP estimate_deltaSEXP, SEXP deltaSEXP, SEXP pseudocountSEXP) {


### PR DESCRIPTION
Hi @joshua-d-campbell, this is to fix the bug reported by issue #355. In brief, the background matrix is ignored when the input class is not SingleCellExperiment.